### PR TITLE
Minor cleanup, comments

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -5,22 +5,21 @@
  * found in the LICENSE file.
  */
 
-#include "SkCanvas.h"
-#include "SkDocument.h"
-#include "SkFontMgr.h"
-#include "SkGradientShader.h"
-#include "SkPaint.h"
-#include "SkStream.h"
-#include "SkString.h"
-#include "SkTextBlob.h"
-#include "SkTypeface.h"
-
-#include <hb.h>
-#include <hb-ot.h>
+// This sample progam demonstrates how to use Skia and HarfBuzz to
+// produce a PDF file from UTF-8 text in stdin.
 
 #include <cassert>
 #include <iostream>
 #include <map>
+#include <string>
+
+#include <hb-ot.h>
+
+#include "SkCanvas.h"
+#include "SkDocument.h"
+#include "SkStream.h"
+#include "SkTextBlob.h"
+#include "SkTypeface.h"
 
 struct BaseOption {
   std::string selector;
@@ -205,7 +204,6 @@ class Placement {
         SkPaint::kSubpixelText_Flag);  // ... avoid waggly text when rotating.
     glyph_paint.setColor(SK_ColorBLACK);
     glyph_paint.setTextSize(config.font_size->value);
-    SkAutoTUnref<SkFontMgr> fm(SkFontMgr::RefDefault());
     glyph_paint.setTypeface(face->fSkiaTypeface);
     glyph_paint.setTextEncoding(SkPaint::kGlyphID_TextEncoding);
 


### PR DESCRIPTION
-   Add `#include <string>`, needed by some standard C++ libraries.
-   Add a small comment at top of source file.
-   Remove unneeded SkFontMgr.
